### PR TITLE
fix: forecast panel hidden behind Leaflet map

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -162,7 +162,7 @@ body {
   left: 0;
   right: 0;
   height: 0;
-  z-index: 10;
+  z-index: 1000; /* Must be above Leaflet panes (z-index 200-800) */
   display: flex;
   flex-direction: column;
   transition: height 0.3s ease;


### PR DESCRIPTION
Fixes #7

Leaflet panes use z-index 200-800. The forecast overlay had z-index 10, so it was invisible behind the map tiles. Bumped to 1000.

Verified in-browser: setting z-index to 1000 makes the panel visible immediately.