### PR TITLE
feat: use actual daylight hours instead of hardcoded 8am-6pm

### DIFF
--- a/forecast.go
+++ b/forecast.go
@@ -60,8 +60,7 @@ func GenerateForecast(site Site, opts ForecastOptions) (*SiteForecast, error) {
 			for _, idx := range indices {
 				h := &hourlyData[idx]
 				lt := h.Time.In(loc)
-				hour := lt.Hour()
-				if hour >= 8 && hour <= 18 {
+				if h.IsDay == 1 {
 					m := ComputeHourlyMetrics(h, site, tc)
 					m.Time = lt
 					df.Hours = append(df.Hours, m)
@@ -79,8 +78,7 @@ func GenerateForecast(site Site, opts ForecastOptions) (*SiteForecast, error) {
 			for _, idx := range indices {
 				h := &hourlyData[idx]
 				lt := h.Time.In(loc)
-				hour := lt.Hour()
-				if hour >= 8 && hour <= 18 {
+				if h.IsDay == 1 {
 					m := ComputeHourlyMetrics(h, site, tc)
 					m.Time = lt
 					dayMetrics = append(dayMetrics, m)

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -216,8 +216,9 @@ async function selectSite(name) {
 }
 
 /**
- * Group an array of hourly metrics by date, keeping only 08:00–18:00 UTC.
- * @param {Array<Object>} metrics - Hourly metric objects with a `time` field.
+ * Group an array of hourly metrics by date, keeping only daylight hours.
+ * Uses the is_day field from Open-Meteo (based on solar position at the site).
+ * @param {Array<Object>} metrics - Hourly metric objects with `time` and `is_day` fields.
  * @returns {Array<{date: string, hours: Array<Object>}>} Grouped days.
  */
 function groupByDay(metrics) {
@@ -227,9 +228,8 @@ function groupByDay(metrics) {
   metrics.forEach(function (hour) {
     var dt = new Date(hour.time);
     var dateKey = dt.toISOString().slice(0, 10);
-    var utcHour = dt.getUTCHours();
 
-    if (utcHour < 8 || utcHour > 18) return;
+    if (!hour.is_day) return;
 
     if (!dayMap[dateKey]) {
       dayMap[dateKey] = [];


### PR DESCRIPTION
Uses Open-Meteo's `is_day` field (based on solar position at the site's coordinates) instead of hardcoded 08:00-18:00 filtering.

- **Winter**: fewer hours shown (e.g. 08:00-17:00 in Feb)
- **Summer**: more hours shown (e.g. 05:00-21:00 in June)
- Affects both CLI (`forecast.go`) and web UI (`ui.js`)
- All tests pass