### PR TITLE
fix: wind profile popups not hiding on mouseout

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -548,9 +548,7 @@ body {
   pointer-events: none;
 }
 
-.wind-profile-cell:hover .wind-profile-popup {
-  display: block;
-}
+/* Show/hide managed by JS (initWindProfilePopups) */
 
 .wp-title {
   font-size: 0.75rem;

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -475,13 +475,28 @@ function initWindProfilePopups() {
   var panel = document.getElementById('forecastPanel');
   if (!panel) return;
 
+  var activePopup = null;
+
   panel.addEventListener('mouseover', function (e) {
     var cell = e.target.closest('.wind-profile-cell');
-    if (!cell) return;
-    var popup = cell.querySelector('.wind-profile-popup');
-    if (!popup) return;
+    if (!cell) {
+      // Mouse moved to non-cell element — hide active popup
+      if (activePopup) {
+        activePopup.style.display = 'none';
+        activePopup = null;
+      }
+      return;
+    }
 
-    // Temporarily show to measure
+    var popup = cell.querySelector('.wind-profile-popup');
+    if (!popup || popup === activePopup) return;
+
+    // Hide previous popup
+    if (activePopup) {
+      activePopup.style.display = 'none';
+    }
+
+    // Measure popup size
     popup.style.visibility = 'hidden';
     popup.style.display = 'block';
     var popupRect = popup.getBoundingClientRect();
@@ -506,5 +521,13 @@ function initWindProfilePopups() {
 
     popup.style.top = top + 'px';
     popup.style.left = left + 'px';
+    activePopup = popup;
+  });
+
+  panel.addEventListener('mouseleave', function () {
+    if (activePopup) {
+      activePopup.style.display = 'none';
+      activePopup = null;
+    }
   });
 }


### PR DESCRIPTION
**Bug:** Fixed-position popups escape the cell's hover bounds, so CSS `:hover` never fires `mouseout` — popups stack up as you move through rows.

**Fix:** Replace CSS `:hover` show/hide with JS-managed state:
- Track active popup, hide previous before showing new
- `mouseleave` on forecast panel hides any active popup
- Moving to non-gradient cells also hides the popup