### PR TITLE
Extract hardcoded strings into centralised strings.go

### DIFF
--- a/format_text.go
+++ b/format_text.go
@@ -12,19 +12,19 @@ func starsStr(n int) string {
 
 func gradientIcon(g string) string {
 	switch g {
-	case "Low": return "✅"
-	case "Medium": return "⚠️"
+	case GradientLow: return "✅"
+	case GradientMedium: return "⚠️"
 	default: return "🔴"
 	}
 }
 
 func thermalIcon(t string) string {
 	switch t {
-	case "None": return "❄️"
-	case "Weak": return "🌤"
-	case "Moderate": return "☀️"
-	case "Strong": return "🔥"
-	case "Extreme": return "⚡"
+	case ThermalNone: return "❄️"
+	case ThermalWeak: return "🌤"
+	case ThermalModerate: return "☀️"
+	case ThermalStrong: return "🔥"
+	case ThermalExtreme: return "⚡"
 	default: return "❓"
 	}
 }
@@ -46,16 +46,16 @@ func rainStr(precip, prob float64) string {
 
 func xcIcon(xc string) string {
 	switch xc {
-	case "Epic": return "🚀"
-	case "High": return "🦅"
-	case "Medium": return "🪂"
+	case XCEpic: return "🚀"
+	case XCHigh: return "🦅"
+	case XCMedium: return "🪂"
 	default: return ""
 	}
 }
 
 // FormatText writes a pretty text forecast to the writer.
 func FormatText(w io.Writer, f *SiteForecast, tc *TuningConfig) {
-	fmt.Fprintf(w, "\n🪂 PARAGLIDING FORECAST — %s\n", f.Site.Name)
+	fmt.Fprintf(w, "\n"+ForecastTitle+"\n", f.Site.Name)
 	fmt.Fprintf(w, "   %s facing | Ideal: %s | Elev: %dm\n",
 		DegreesToCompass(float64(f.Site.Aspect)),
 		windRangeStr(f.Site.WindMin, f.Site.WindMax, f.Site.BestDir),
@@ -63,13 +63,13 @@ func FormatText(w io.Writer, f *SiteForecast, tc *TuningConfig) {
 	fmt.Fprintf(w, "   Generated: %s\n", f.Generated.Format("Mon 2 Jan 2006 15:04 MST"))
 
 	for i, day := range f.DetailedDays {
-		label := "TODAY"
-		if i == 1 { label = "TOMORROW" }
+		label := LabelToday
+		if i == 1 { label = LabelTomorrow }
 		if i >= 2 { label = day.Date.Format("Mon 2 Jan") }
 		
 		fmt.Fprintf(w, "\n━━━ %s (%s) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n", label, day.Date.Format("Mon 2 Jan"))
 		fmt.Fprintf(w, "        %-8s %-5s %-6s %-9s %-10s %-5s %-6s %s\n",
-			"Wind", "Dir", "Gust", "Gradient", "Thermal", "Cloud", "Rain", "Score")
+			HeaderWind, HeaderDir, HeaderGust, HeaderGradient, HeaderThermal, HeaderCloud, HeaderRain, HeaderScore)
 
 		for _, h := range day.Hours {
 			fmt.Fprintf(w, "%s  %-8s %-5s %-6s %s %-5s %s %-7s %-5s %-6s %s\n",
@@ -89,17 +89,17 @@ func FormatText(w io.Writer, f *SiteForecast, tc *TuningConfig) {
 		s := day.Summary
 		if len(day.Hours) > 0 {
 			h0 := day.Hours[len(day.Hours)/2] // mid-day representative
-			fmt.Fprintf(w, "\nCloudbase: ~%s | CAPE: %.0f J/kg | Freezing: %.0fft\n",
+			fmt.Fprintf(w, "\n"+CloudbaseLabel+"\n",
 				CloudbaseStr(h0.CloudbaseFt, tc), h0.CAPE, h0.FreezingLevel)
-			fmt.Fprintf(w, "Orographic: %s\n", h0.OrographicLift)
-			fmt.Fprintf(w, "XC Potential: %s %s\n", s.XCPotential, xcIcon(s.XCPotential))
+			fmt.Fprintf(w, OrographicLabel+"\n", h0.OrographicLift)
+			fmt.Fprintf(w, XCLabel+"\n", s.XCPotential, xcIcon(s.XCPotential))
 		}
 	}
 
 	if len(f.ExtendedDays) > 0 {
-		fmt.Fprintf(w, "\n━━━ EXTENDED OUTLOOK ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+		fmt.Fprintf(w, "\n━━━ "+ExtendedOutlookTitle+" ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 		fmt.Fprintf(w, "%-12s %-10s %-6s %-10s %-6s %s\n",
-			"Day", "Wind", "Dir", "Thermal", "Rain", "Score")
+			HeaderDay, HeaderExtWind, HeaderExtDir, HeaderExtThermal, HeaderExtRain, HeaderExtScore)
 		for _, d := range f.ExtendedDays {
 			fmt.Fprintf(w, "%-12s %-10s %-6s %-10s %-6s %s\n",
 				d.Date.Format("Mon 2 Jan"),
@@ -112,7 +112,7 @@ func FormatText(w io.Writer, f *SiteForecast, tc *TuningConfig) {
 	}
 
 	if f.BestWindow != "" {
-		fmt.Fprintf(w, "\n🏆 Best Window: %s\n", f.BestWindow)
+		fmt.Fprintf(w, "\n"+BestWindowLabel+"\n", f.BestWindow)
 	}
 	fmt.Fprintln(w)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -100,11 +100,11 @@ func CalcWindGradient(surface float64, levels []PressureLevel, tc *TuningConfig)
 	}
 	switch {
 	case diff < tc.Gradient.LowThreshold:
-		rating = "Low"
+		rating = GradientLow
 	case diff < tc.Gradient.HighThreshold:
-		rating = "Medium"
+		rating = GradientMedium
 	default:
-		rating = "High"
+		rating = GradientHigh
 	}
 	return
 }
@@ -133,15 +133,15 @@ func CalcThermalRating(cape float64, levels []PressureLevel, tc *TuningConfig) s
 
 	switch {
 	case score >= 5:
-		return "Extreme"
+		return ThermalExtreme
 	case score >= 4:
-		return "Strong"
+		return ThermalStrong
 	case score >= 3:
-		return "Moderate"
+		return ThermalModerate
 	case score >= 1:
-		return "Weak"
+		return ThermalWeak
 	default:
-		return "None"
+		return ThermalNone
 	}
 }
 
@@ -170,13 +170,13 @@ func calcLapseRate(levels []PressureLevel) float64 {
 func CalcCAPERating(cape float64, tc *TuningConfig) string {
 	switch {
 	case cape >= tc.Thermal.CAPEExtreme:
-		return "Overdevelopment"
+		return CAPEOverdevelopment
 	case cape >= tc.Thermal.CAPEStrong:
-		return "Strong"
+		return CAPEStrong
 	case cape >= tc.Thermal.CAPEModerate:
-		return "Moderate"
+		return CAPEModerate
 	default:
-		return "Weak"
+		return CAPEWeak
 	}
 }
 
@@ -196,7 +196,7 @@ func CalcCloudbaseFt(temp, dewpoint float64, tc *TuningConfig) int {
 // CloudbaseStr returns a display string for cloudbase, showing "Fog" for very low values.
 func CloudbaseStr(ft int, tc *TuningConfig) string {
 	if ft <= tc.Cloudbase.MinRealisticFt {
-		return "Fog"
+		return CloudbaseFog
 	}
 	return fmt.Sprintf("%dft", ft)
 }
@@ -206,18 +206,18 @@ func CalcOrographicLift(windDir, windSpeed float64, siteAspect int, tc *TuningCo
 	diff := angleDiff(windDir, float64(siteAspect))
 
 	if windSpeed < tc.Orographic.MinWindSpeed {
-		return "None"
+		return OrographicNone
 	}
 
 	switch {
 	case diff <= tc.Orographic.StrongAngle:
-		return "Strong"
+		return OrographicStrong
 	case diff <= tc.Orographic.ModerateAngle:
-		return "Moderate"
+		return OrographicModerate
 	case diff <= tc.Orographic.WeakAngle:
-		return "Weak"
+		return OrographicWeak
 	default:
-		return "None"
+		return OrographicNone
 	}
 }
 
@@ -277,9 +277,9 @@ func CalcFlyabilityScore(h *HourlyData, site Site, gradientRating string, therma
 
 	// Wind gradient (NEW - was missing from scoring)
 	switch gradientRating {
-	case "High":
+	case GradientHigh:
 		score += s.GradientHighPenalty
-	case "Medium":
+	case GradientMedium:
 		score += s.GradientMedPenalty
 	}
 
@@ -296,7 +296,7 @@ func CalcFlyabilityScore(h *HourlyData, site Site, gradientRating string, therma
 	if h.CAPE >= tc.Thermal.CAPEModerate && h.CAPE < tc.Thermal.CAPEExtreme {
 		score += s.CAPEBonus
 	}
-	if thermalRating == "Strong" || thermalRating == "Moderate" {
+	if thermalRating == ThermalStrong || thermalRating == ThermalModerate {
 		score += s.ThermalStrongBonus
 	}
 
@@ -350,23 +350,23 @@ func CalcXCPotential(cape float64, cloudbaseFt int, windSpeed float64, thermalRa
 		score++
 	}
 	switch thermalRating {
-	case "Strong":
+	case ThermalStrong:
 		score += 2
-	case "Moderate":
+	case ThermalModerate:
 		score++
-	case "Extreme":
+	case ThermalExtreme:
 		score++
 	}
 
 	switch {
 	case score >= tc.XC.EpicThreshold:
-		return "Epic"
+		return XCEpic
 	case score >= tc.XC.HighThreshold:
-		return "High"
+		return XCHigh
 	case score >= tc.XC.MediumThreshold:
-		return "Medium"
+		return XCMedium
 	default:
-		return "Low"
+		return XCLow
 	}
 }
 

--- a/strings.go
+++ b/strings.go
@@ -1,0 +1,86 @@
+package pgforecast
+
+// User-facing string constants, centralised for future localization.
+
+// Wind gradient ratings.
+const (
+	GradientLow    = "Low"
+	GradientMedium = "Medium"
+	GradientHigh   = "High"
+)
+
+// Thermal ratings.
+const (
+	ThermalNone     = "None"
+	ThermalWeak     = "Weak"
+	ThermalModerate = "Moderate"
+	ThermalStrong   = "Strong"
+	ThermalExtreme  = "Extreme"
+)
+
+// CAPE ratings.
+const (
+	CAPEOverdevelopment = "Overdevelopment"
+	CAPEStrong          = "Strong"
+	CAPEModerate        = "Moderate"
+	CAPEWeak            = "Weak"
+)
+
+// Orographic lift ratings.
+const (
+	OrographicNone     = "None"
+	OrographicWeak     = "Weak"
+	OrographicModerate = "Moderate"
+	OrographicStrong   = "Strong"
+)
+
+// XC potential ratings.
+const (
+	XCEpic   = "Epic"
+	XCHigh   = "High"
+	XCMedium = "Medium"
+	XCLow    = "Low"
+)
+
+// Cloudbase display strings.
+const (
+	CloudbaseFog = "Fog"
+)
+
+// Format labels used in text output.
+const (
+	LabelToday    = "TODAY"
+	LabelTomorrow = "TOMORROW"
+)
+
+// Column headers for detailed forecast.
+const (
+	HeaderWind     = "Wind"
+	HeaderDir      = "Dir"
+	HeaderGust     = "Gust"
+	HeaderGradient = "Gradient"
+	HeaderThermal  = "Thermal"
+	HeaderCloud    = "Cloud"
+	HeaderRain     = "Rain"
+	HeaderScore    = "Score"
+)
+
+// Column headers for extended outlook.
+const (
+	HeaderDay          = "Day"
+	HeaderExtWind      = "Wind"
+	HeaderExtDir       = "Dir"
+	HeaderExtThermal   = "Thermal"
+	HeaderExtRain      = "Rain"
+	HeaderExtScore     = "Score"
+	ExtendedOutlookTitle = "EXTENDED OUTLOOK"
+)
+
+// Format strings and labels.
+const (
+	ForecastTitle   = "🪂 PARAGLIDING FORECAST — %s"
+	BestWindowLabel = "🏆 Best Window: %s"
+	CloudbaseLabel  = "Cloudbase: ~%s | CAPE: %.0f J/kg | Freezing: %.0fft"
+	OrographicLabel = "Orographic: %s"
+	XCLabel         = "XC Potential: %s %s"
+)


### PR DESCRIPTION
Moves all user-facing string literals (rating labels, format strings, column headers) into exported constants in `strings.go`. Updates `metrics.go` and `format_text.go` to use these constants.

This makes future localization straightforward — all strings are in one place.

Closes #20