### PR TITLE
fix: handle WASM output format change in loadAllSitesOverview

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -35,6 +35,31 @@ var activeTuning = null;
 var TUNING_STORAGE_KEY = 'pgforecast_tuning';
 
 /**
+ * Cached display config from the WASM output.
+ * Set by selectSite or loadAllSitesOverview when WASM returns results.
+ * @type {Object|null}
+ */
+var displayConfig = null;
+
+/**
+ * Cached wind thresholds from the WASM output.
+ * @type {Object|null}
+ */
+var windThresholds = null;
+
+/**
+ * Apply display config colours as CSS custom properties on :root.
+ * This allows CSS gradient classes to use config-driven colours.
+ * @param {Object} dc - Display config object from WASM.
+ */
+function applyDisplayConfigCSS(dc) {
+  var root = document.documentElement;
+  root.style.setProperty('--good', dc.gradient.low.rgb);
+  root.style.setProperty('--warn', dc.gradient.medium.rgb);
+  root.style.setProperty('--bad', dc.gradient.high.rgb);
+}
+
+/**
  * Load all site forecasts in the background.
  * Fetches weather data for each site, computes metrics via WASM,
  * and updates the sidebar and map markers as results arrive.
@@ -55,11 +80,13 @@ async function loadAllSitesOverview() {
         const days = groupByDay(metrics);
         let bestScore = 0;
 
-        // Apply display config from the first successful result
-        if (result.display && !displayConfig) {
+        // Apply display config from the first successful result, but only
+        // when both display and wind_thresholds are present to avoid
+        // inconsistent global state.
+        if (result.display && result.wind_thresholds && !displayConfig) {
           displayConfig = result.display;
           windThresholds = result.wind_thresholds;
-          applyDisplayConfigCSS(result.display);
+          applyDisplayConfigCSS(displayConfig);
         }
 
         days.slice(0, 3).forEach(function (day) {

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -136,31 +136,6 @@ function windArrow(deg) {
 }
 
 /**
- * Cached display config from the WASM output.
- * Set by selectSite when WASM returns results.
- * @type {Object|null}
- */
-var displayConfig = null;
-
-/**
- * Cached wind thresholds from the WASM output.
- * @type {Object|null}
- */
-var windThresholds = null;
-
-/**
- * Apply display config colours as CSS custom properties on :root.
- * This allows CSS gradient classes to use config-driven colours.
- * @param {Object} dc - Display config object from WASM.
- */
-function applyDisplayConfigCSS(dc) {
-  var root = document.documentElement;
-  root.style.setProperty('--good', dc.gradient.low.rgb);
-  root.style.setProperty('--warn', dc.gradient.medium.rgb);
-  root.style.setProperty('--bad', dc.gradient.high.rgb);
-}
-
-/**
  * Get a colour for wind speed (mph) using config-driven thresholds.
  * Falls back to hardcoded values if config not loaded.
  * Thresholds derive from wind tuning: ideal_min, ideal_max, acceptable_max, dangerous_max.


### PR DESCRIPTION
Fixes the regression from PR #27 where `loadAllSitesOverview()` in `app.js` wasn't updated for the new WASM output format `{metrics, display, wind_thresholds}`.

**Changes:**
- Extract `result.metrics || result` before `groupByDay()`
- Apply `displayConfig`/`windThresholds` from the first successful WASM result
- Log errors to console instead of silently swallowing

Closes #29