### PR TITLE
feat: single-step map centering + marker selection highlight

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -714,3 +714,12 @@ body {
   text-align: center;
   font-size: 1.1rem;
 }
+
+/* --- Pulsing marker selection ring --- */
+.marker-pulse {
+  animation: marker-pulse 1.5s ease-in-out infinite;
+}
+@keyframes marker-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 0.2; }
+}

--- a/web/js/map.js
+++ b/web/js/map.js
@@ -39,6 +39,7 @@ function initMap() {
   map.on('click', function () {
     if (selectedSite) {
       selectedSite = null;
+      clearMarkerHighlight();
       renderSiteList();
       hideForecastPanel();
     }
@@ -62,5 +63,54 @@ function updateMarkerColor(name, score) {
       fillOpacity: score >= 4 ? 0.9 : 0.7
     });
     marker.setRadius(radii[score] || 6);
+  }
+}
+
+/**
+ * Highlight the selected marker with a pulsing ring and reset the previous one.
+ * @param {string} name - Site name to highlight.
+ */
+function highlightMarker(name) {
+  // Remove previous highlight
+  if (highlightMarker._ring) {
+    map.removeLayer(highlightMarker._ring);
+    highlightMarker._ring = null;
+  }
+  if (highlightMarker._prevName && markers[highlightMarker._prevName]) {
+    markers[highlightMarker._prevName].setStyle({ weight: 2, color: '#2d3748' });
+  }
+
+  var marker = markers[name];
+  if (!marker) return;
+
+  // Bold the selected marker border
+  marker.setStyle({ weight: 3, color: '#ffffff' });
+
+  // Add a pulsing ring around the selected marker
+  var latlng = marker.getLatLng();
+  highlightMarker._ring = L.circleMarker(latlng, {
+    radius: marker.getRadius() + 8,
+    fillColor: 'transparent',
+    fillOpacity: 0,
+    color: '#ffffff',
+    weight: 2,
+    opacity: 0.6,
+    className: 'marker-pulse'
+  }).addTo(map);
+
+  highlightMarker._prevName = name;
+}
+
+/**
+ * Remove marker highlight (used when deselecting).
+ */
+function clearMarkerHighlight() {
+  if (highlightMarker._ring) {
+    map.removeLayer(highlightMarker._ring);
+    highlightMarker._ring = null;
+  }
+  if (highlightMarker._prevName && markers[highlightMarker._prevName]) {
+    markers[highlightMarker._prevName].setStyle({ weight: 2, color: '#2d3748' });
+    highlightMarker._prevName = null;
   }
 }

--- a/web/js/map.js
+++ b/web/js/map.js
@@ -63,6 +63,11 @@ function updateMarkerColor(name, score) {
       fillOpacity: score >= 4 ? 0.9 : 0.7
     });
     marker.setRadius(radii[score] || 6);
+
+    // Sync highlight ring radius if this marker is currently selected
+    if (highlightMarker._prevName === name && highlightMarker._ring) {
+      highlightMarker._ring.setRadius((radii[score] || 6) + 8);
+    }
   }
 }
 
@@ -111,6 +116,6 @@ function clearMarkerHighlight() {
   }
   if (highlightMarker._prevName && markers[highlightMarker._prevName]) {
     markers[highlightMarker._prevName].setStyle({ weight: 2, color: '#2d3748' });
-    highlightMarker._prevName = null;
   }
+  highlightMarker._prevName = null;
 }

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -287,12 +287,6 @@ async function selectSite(name) {
   var site = SITES.find(function (s) { return s.name === name; });
   if (!site) return;
 
-  // Cancel any pending recenter handler from a previous selection
-  if (selectSite._pendingRecenter) {
-    map.off('moveend', selectSite._pendingRecenter);
-    selectSite._pendingRecenter = null;
-  }
-
   if (isMobile()) {
     closeSidebar();
   }


### PR DESCRIPTION
Three improvements to site selection:

1. **Works on all viewports** — removed `isMobile()` check, centering now happens on desktop too
2. **Single-step flyTo** — projects site coords to pixels at target zoom, offsets by 25% of map height, unpprojects back. No more flyTo → moveend → panBy two-step dance
3. **Visual selection indicator** — selected marker gets a white border and a pulsing ring, cleared on deselect