### PR TITLE
fix: safe area layout — flexbox + dvh replaces hardcoded calc

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -25,8 +25,8 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  height: 100dvh;
-  height: 100vh; /* fallback for browsers without dvh */
+  height: 100vh;
+  height: 100dvh; /* override for browsers with dvh support */
   padding-top: env(safe-area-inset-top, 0px);
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
@@ -248,7 +248,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  padding-top: 60px;
+  padding-top: calc(60px + env(safe-area-inset-top, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .tuning-panel {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -23,13 +23,18 @@ body {
   background: var(--bg);
   color: var(--text);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  height: 100vh; /* fallback for browsers without dvh */
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* --- Header --- */
 
 .header {
   padding: 0.75rem 1.5rem;
-  padding-top: calc(0.75rem + env(safe-area-inset-top, 0px));
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -37,6 +42,7 @@ body {
   min-height: 50px;
   z-index: 10;
   position: relative;
+  flex-shrink: 0;
 }
 
 /* --- Hamburger button (mobile only) --- */
@@ -93,7 +99,8 @@ body {
 
 .layout {
   display: flex;
-  height: calc(100vh - 50px - env(safe-area-inset-top, 0px));
+  flex: 1;
+  min-height: 0;
 }
 
 /* --- Sidebar overlay (mobile) --- */
@@ -111,7 +118,6 @@ body {
   flex-shrink: 0;
   z-index: 5;
   background: var(--bg);
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .sidebar-header {
@@ -221,7 +227,6 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: 1rem 1.5rem;
-  padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   background: var(--bg);
   min-height: 0;
 }
@@ -497,11 +502,11 @@ body {
 
 .status-bar {
   padding: 0.4rem 1rem;
-  padding-bottom: calc(0.4rem + env(safe-area-inset-bottom, 0px));
   background: var(--card);
   border-top: 1px solid var(--border);
   font-size: 0.7rem;
   color: var(--muted);
+  flex-shrink: 0;
 }
 
 /* --- Spinner --- */


### PR DESCRIPTION
Fixes safe area issues on iOS Safari (header behind notch) and Edge (bottom obscured).

**Root cause:** `calc(100vh - 50px - safe-area)` broke because:
- 50px was hardcoded but header grows with safe-area padding
- `env()` support varies, `100vh` doesn't account for browser chrome

**Fix:** Full flexbox layout:
- `body`: flex column, `height: 100dvh` (with 100vh fallback), `padding-top/bottom` for safe areas
- `.header` + `.status-bar`: `flex-shrink: 0`  
- `.layout`: `flex: 1; min-height: 0`
- No more hardcoded height calcs
- Individual element safe-area padding removed (body handles it globally)